### PR TITLE
changed the look of credit link, changed wizards to creators

### DIFF
--- a/public/credit.html
+++ b/public/credit.html
@@ -54,7 +54,7 @@
     </article>
     <footer>
       <a href="//twitter.com/intent/tweet?button_hashtag=StandWithDuwamish" class="twitter-hashtag-button" data-size="large">Tweet #StandWithDuwamish</a>
-      <a href="credit.html"><p class="teenytiny">Wizards</p></a>
+      <p class="teenytiny"><a href="credit.html">Creators</a></p>
     </footer>
   </body>
     <script type="text/javascript" src="js/app.js"></script>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -281,4 +281,17 @@ footer a{
 .teenytiny {
   text-decoration: none;
   color: black;
-  font-size: 75%; }
+  font-size: 75%;
+  }
+
+.teenytiny a {
+  color:black;
+  padding: 5px 20px;
+  display:inline-block;
+  background-color: #F6B316;
+  border-radius: 5px;
+  box-shadow: 1px 1px 1px #000;
+  margin-top: 20px;
+
+}
+

--- a/public/donate.html
+++ b/public/donate.html
@@ -50,7 +50,7 @@
     </section>
     <footer>
       <a href="//twitter.com/intent/tweet?button_hashtag=StandWithDuwamish" class="twitter-hashtag-button" data-size="large">Tweet #StandWithDuwamish</a>
-      <a href="credit.html"><p class="teenytiny">Wizards</p></a>
+      <p class="teenytiny"><a href="credit.html">Creators</a></p>
     </footer>
     <script type="text/javascript" src="js/app.js">
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
     </section>
     <footer>
       <a href="https://twitter.com/intent/tweet?button_hashtag=StandWithDuwamish" class="twitter-hashtag-button" data-size="large">Tweet #StandWithDuwamish</a>
-      <a href="credit.html"><p class="teenytiny">Wizards</p></a>
+     <p class="teenytiny"><a href="credit.html">Creators</a></p>
     </footer>
   </body>
     <script type="text/javascript" src="js/app.js">

--- a/public/learn.html
+++ b/public/learn.html
@@ -37,7 +37,7 @@
     <iframe src='//cdn.knightlab.com/libs/timeline/latest/embed/index.html?source=1LLlmrbT7JnwsCuI-RegFEoz5m4iUxvfio7YOc0D9aGk&font=Bevan-PotanoSans&maptype=toner&lang=en&height=650' width='100%' height='650' frameborder='0'></iframe>
     <footer>
       <a href="https://twitter.com/intent/tweet?button_hashtag=StandWithDuwamish" class="twitter-hashtag-button" data-size="large">Tweet #StandWithDuwamish</a>
-      <a href="credit.html"><p class="teenytiny">Wizards</p></a>
+      <p class="teenytiny"><a href="credit.html">Creators</a></p>
     </footer>
   </body>
   <script type="text/javascript" src="js/app.js"></script>

--- a/public/takeastand.html
+++ b/public/takeastand.html
@@ -89,7 +89,7 @@
         <a id="emailLink" href="#"><button class="emailbutton" type="submit">Send my letter</button></a>
       <footer>
         <a href="https://twitter.com/intent/tweet?button_hashtag=StandWithDuwamish" class="twitter-hashtag-button" data-size="large">Tweet #StandWithDuwamish</a>
-        <a href="credit.html"><p class="teenytiny">Wizards</p></a>
+        <p class="teenytiny"><a href="credit.html">Creators</a></p>
       </footer>
       </section>
     </article>


### PR DESCRIPTION
I changed the look and feel of the link that gave creators credit. Eventually, I'd also like to change the position of the tweet  "#standwithduwamish" button. Perhaps, in the middle of page? This is something to think about in the future.  I think it would now make sense to change because there is tweet functionality on the 'take stand page'. 
